### PR TITLE
Gama balance Phase 1

### DIFF
--- a/Assets/Images/Erica-Eagles--P1--Team-Freezer--Health-Icon-w-Box.png.meta
+++ b/Assets/Images/Erica-Eagles--P1--Team-Freezer--Health-Icon-w-Box.png.meta
@@ -1,0 +1,127 @@
+fileFormatVersion: 2
+guid: 3c2a80f75f4c34a47862e0bf0e45bb79
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Images/Erica-Eagles--P1--Team-Freezer--Mana-Icon-w-Box.png.meta
+++ b/Assets/Images/Erica-Eagles--P1--Team-Freezer--Mana-Icon-w-Box.png.meta
@@ -1,0 +1,127 @@
+fileFormatVersion: 2
+guid: 0c41a754ee32b9e47a2b9d24766cdb02
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Images/Erica-Eagles--P1--Team-Freezer--Money-Icon-w-Box.png.meta
+++ b/Assets/Images/Erica-Eagles--P1--Team-Freezer--Money-Icon-w-Box.png.meta
@@ -1,0 +1,127 @@
+fileFormatVersion: 2
+guid: eb4a05a993da1804da679f51f7fcf85b
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Images/Erica-Eagles--P1--Team-Freezer--Tower-Icon-BG.png.meta
+++ b/Assets/Images/Erica-Eagles--P1--Team-Freezer--Tower-Icon-BG.png.meta
@@ -1,0 +1,127 @@
+fileFormatVersion: 2
+guid: 7e7c5e0b90801fe468ea1a13487d9972
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemies/BasicEnemy.prefab
+++ b/Assets/Prefabs/Enemies/BasicEnemy.prefab
@@ -72,7 +72,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 10
-  moneyToPlayer: 10
+  moneyToPlayer: 6
   currentHealth: 0
   speed: 4
   damageResistance: 1

--- a/Assets/Prefabs/Enemies/FastEnemy.prefab
+++ b/Assets/Prefabs/Enemies/FastEnemy.prefab
@@ -222,7 +222,7 @@ MonoBehaviour:
   maxHealth: 5
   moneyToPlayer: 5
   currentHealth: 0
-  speed: 8
+  speed: 6
   damageResistance: 1
   ID: 0
   nodeIndex: 0

--- a/Assets/Prefabs/Enemies/Ghost.prefab
+++ b/Assets/Prefabs/Enemies/Ghost.prefab
@@ -221,13 +221,61 @@ MonoBehaviour:
   maxHealth: 10
   moneyToPlayer: 10
   currentHealth: 0
-  speed: 4
+  speed: 5
   damageResistance: 2
   ID: 0
   nodeIndex: 0
   navMeshMovement: {fileID: 0}
   isStunned: 0
   isConfused: 0
+  audioMovement:
+    audioFile: {fileID: 0}
+    volume: 1
+    pitch: 1
+    loop: 0
+    panStereo: 0
+    spatialBlend: 0
+    minDistance: 0
+    maxDistance: 0
+    playOnAwake: 0
+    frequentSound: 0
+    mute: 0
+    showHiddenValues: 0
+    audioMixer: {fileID: 0}
+    bypassEffects: 0
+    bypassListenerEffects: 0
+    bypassReverbZones: 0
+    priority: 128
+    reverbZoneMix: 1
+    dopplerLevel: 1
+    spread: 0
+    ignoeListenerVolume: 0
+    ignoreListenerPause: 0
+    audioRollOffMode: 1
+  audioDead:
+    audioFile: {fileID: 0}
+    volume: 1
+    pitch: 1
+    loop: 0
+    panStereo: 0
+    spatialBlend: 0
+    minDistance: 0
+    maxDistance: 0
+    playOnAwake: 0
+    frequentSound: 0
+    mute: 0
+    showHiddenValues: 0
+    audioMixer: {fileID: 0}
+    bypassEffects: 0
+    bypassListenerEffects: 0
+    bypassReverbZones: 0
+    priority: 128
+    reverbZoneMix: 1
+    dopplerLevel: 1
+    spread: 0
+    ignoeListenerVolume: 0
+    ignoreListenerPause: 0
+    audioRollOffMode: 1
 --- !u!54 &-2798963494309680573
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemies/SlowEnemy.prefab
+++ b/Assets/Prefabs/Enemies/SlowEnemy.prefab
@@ -6982,9 +6982,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 32
-  moneyToPlayer: 20
+  moneyToPlayer: 12
   currentHealth: 0
-  speed: 0.5
+  speed: 3
   damageResistance: 2
   ID: 0
   nodeIndex: 0

--- a/Assets/Prefabs/Towers/BasicTower.prefab
+++ b/Assets/Prefabs/Towers/BasicTower.prefab
@@ -90,11 +90,12 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 64
   damage: 1
-  fireRate: 2
-  range: 4
+  fireRate: 1
+  range: 2
   cost: 100
   isSelected: 0
   towerType: 0
+  targetType: 0
   canvas: {fileID: 0}
   upgradeLevel: 0
 --- !u!114 &3569067476125886872

--- a/Assets/Prefabs/Towers/Cannon Tower.prefab
+++ b/Assets/Prefabs/Towers/Cannon Tower.prefab
@@ -201,12 +201,15 @@ MonoBehaviour:
   enemiesLayer:
     serializedVersion: 2
     m_Bits: 64
-  damage: 2
-  fireRate: 1
-  range: 4
-  cost: 400
+  damage: 1
+  fireRate: 2
+  range: 3
+  cost: 150
   isSelected: 0
   towerType: 2
+  targetType: 0
+  canvas: {fileID: 0}
+  upgradeLevel: 0
 --- !u!114 &2543761900036560489
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Towers/EconomyTower.prefab
+++ b/Assets/Prefabs/Towers/EconomyTower.prefab
@@ -92,9 +92,12 @@ MonoBehaviour:
   damage: 0
   fireRate: 0
   range: 0
-  cost: 150
+  cost: 130
   isSelected: 0
   towerType: 3
+  targetType: 0
+  canvas: {fileID: 0}
+  upgradeLevel: 0
 --- !u!65 &2257491692670457906
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -128,6 +131,30 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 940ec9e5b5aa31d468f7086a2062004e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  audioData:
+    audioFile: {fileID: 0}
+    volume: 1
+    pitch: 1
+    loop: 0
+    panStereo: 0
+    spatialBlend: 0
+    minDistance: 0
+    maxDistance: 0
+    playOnAwake: 0
+    frequentSound: 0
+    mute: 0
+    showHiddenValues: 0
+    audioMixer: {fileID: 0}
+    bypassEffects: 0
+    bypassListenerEffects: 0
+    bypassReverbZones: 0
+    priority: 128
+    reverbZoneMix: 1
+    dopplerLevel: 1
+    spread: 0
+    ignoeListenerVolume: 0
+    ignoreListenerPause: 0
+    audioRollOffMode: 1
 --- !u!114 &-4824812572669455108
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Towers/Flame Tower.prefab
+++ b/Assets/Prefabs/Towers/Flame Tower.prefab
@@ -90,10 +90,10 @@ MonoBehaviour:
   enemiesLayer:
     serializedVersion: 2
     m_Bits: 64
-  damage: 0.1
-  fireRate: 5
+  damage: 1
+  fireRate: 2
   range: 2
-  cost: 300
+  cost: 110
   isSelected: 0
   towerType: 1
   targetType: 0

--- a/Assets/Prefabs/Towers/Ice Tower.prefab
+++ b/Assets/Prefabs/Towers/Ice Tower.prefab
@@ -538,11 +538,14 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 64
   damage: 0
-  fireRate: 0.5
-  range: 6
-  cost: 250
+  fireRate: 0.25
+  range: 5
+  cost: 170
   isSelected: 0
   towerType: 4
+  targetType: 0
+  canvas: {fileID: 0}
+  upgradeLevel: 0
 --- !u!114 &7798354543586379515
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Towers/Support Tower.prefab
+++ b/Assets/Prefabs/Towers/Support Tower.prefab
@@ -422,10 +422,13 @@ MonoBehaviour:
     m_Bits: 64
   damage: 0
   fireRate: 0
-  range: 3
-  cost: 200
+  range: 5
+  cost: 150
   isSelected: 0
   towerType: 5
+  targetType: 0
+  canvas: {fileID: 0}
+  upgradeLevel: 0
 --- !u!114 &7706323465444112875
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Prototyping Scene - EDITOR ONLY/GameScene.unity
+++ b/Assets/Scenes/Prototyping Scene - EDITOR ONLY/GameScene.unity
@@ -2089,7 +2089,7 @@ PrefabInstance:
     - target: {fileID: 7214225948648353714, guid: 9973a4b1fa88a3b4eb4e1c173243ff66,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -0.00024414062
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7214225948648353714, guid: 9973a4b1fa88a3b4eb4e1c173243ff66,
         type: 3}
@@ -34900,6 +34900,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -2.230957
+      objectReference: {fileID: 0}
+    - target: {fileID: 5380433826335304610, guid: d29164d4bd37749458e7a488930fbf17,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 2.1308594
       objectReference: {fileID: 0}
     - target: {fileID: 5877783961408362001, guid: d29164d4bd37749458e7a488930fbf17,
         type: 3}


### PR DESCRIPTION
I adjusted the reduced the damage and shooting distance of towers. enemies speed were also adjusted.  Giving a less than 0.2 win probability without using Mana towers. The Mana towers comes as backup for the endangered player. Cost for towers
Basic : 100, Flame: 110, Canon: 150, Ice: 170, support:150, Economy:130. Their damages also lowered. Check hiearachy values.

## Changes
<!-- Provide a list of high level changes for your work on this Pull Request. -->

### Known Bugs/Issues

## Testing Scene and Script
<!--- Provide the name of the scene(s) and scripts that the reviewer needs to check to make sure your task is finished -->

## Issue ticket number/link
<!--- Provide a link or ticket number for an associated issue -->

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] Make sure I am merging my features into the `develop` branch
- [ ] I have notified the other members of the programming team that my task is ready to review
