### PR TITLE
Path bug fix

### DIFF
--- a/Assets/Prefabs/GameScene/Player.prefab
+++ b/Assets/Prefabs/GameScene/Player.prefab
@@ -280,7 +280,7 @@ MonoBehaviour:
     type: 3}
   confusionPreviewPrefab: {fileID: 919132149155446097, guid: 8eb2969f86aa81440afd0dec2866bf3a,
     type: 3}
-  meteorPrefab: {fileID: 6325297206059727315, guid: c2c8308e4c2a9a248a918ca53cb19d54,
+  meteorPrefab: {fileID: 830794206325096820, guid: 226f321f7102b9c41b5a43acaf784d7d,
     type: 3}
   lightningPrefab: {fileID: 2695104058712217552, guid: 338619145f25b3343a885ba90e294f0f,
     type: 3}
@@ -290,6 +290,12 @@ MonoBehaviour:
   meteorCost: 100
   lightningCost: 50
   confusionCost: 50
+  meteorCooldown: 5
+  lightningCooldown: 7
+  confusionCooldown: 6
   meteorCooldownText: {fileID: 0}
   lightningCooldownText: {fileID: 0}
   confusionCooldownText: {fileID: 0}
+  meteorKeyMask: {fileID: 0}
+  lightningKeyMask: {fileID: 0}
+  confusionKeyMask: {fileID: 0}

--- a/Assets/Prefabs/UI/Canvas.prefab
+++ b/Assets/Prefabs/UI/Canvas.prefab
@@ -3411,6 +3411,99 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1961321689321425547
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8603892743095651066}
+  - component: {fileID: 1637442840211545176}
+  - component: {fileID: 2319110394411121848}
+  - component: {fileID: 667621789133304086}
+  m_Layer: 5
+  m_Name: Lightning  Key Mask
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8603892743095651066
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961321689321425547}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5134214698936574490}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.000015258789}
+  m_SizeDelta: {x: 61.324, y: 61.324}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &1637442840211545176
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961321689321425547}
+  m_CullTransparentMesh: 1
+--- !u!114 &2319110394411121848
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961321689321425547}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9098039, g: 0.34901962, b: 0.34901962, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4aefccd10a1c44e4e98110b95d6c80e9, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 0
+  m_FillClockwise: 0
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &667621789133304086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1961321689321425547}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ae2d6af53fbe6db40a20f4a4b0bf6790, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maskImage: {fileID: 0}
+  wipeDuration: 5
+  timer: 0
+  isWiping: 0
+  rune: 1
 --- !u!1 &2035001095065931579
 GameObject:
   m_ObjectHideFlags: 0
@@ -5761,6 +5854,99 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3428076354966198461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 18962347362536874}
+  - component: {fileID: 3622650086552412938}
+  - component: {fileID: 8707282189976412713}
+  - component: {fileID: 5119697736559320303}
+  m_Layer: 5
+  m_Name: Confusion  Key Mask
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &18962347362536874
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3428076354966198461}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4375124505080933168}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.000015258789}
+  m_SizeDelta: {x: 61.324, y: 61.324}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &3622650086552412938
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3428076354966198461}
+  m_CullTransparentMesh: 1
+--- !u!114 &8707282189976412713
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3428076354966198461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9098039, g: 0.34901962, b: 0.34901962, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4aefccd10a1c44e4e98110b95d6c80e9, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 0
+  m_FillClockwise: 0
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5119697736559320303
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3428076354966198461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ae2d6af53fbe6db40a20f4a4b0bf6790, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maskImage: {fileID: 0}
+  wipeDuration: 5
+  timer: 0
+  isWiping: 0
+  rune: 2
 --- !u!1 &3431315019078003327
 GameObject:
   m_ObjectHideFlags: 0
@@ -6983,6 +7169,99 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4069877967412693113
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2987331137401676974}
+  - component: {fileID: 7436112283728199014}
+  - component: {fileID: 5616646902986122397}
+  - component: {fileID: 7893306725387225855}
+  m_Layer: 5
+  m_Name: Meteor Key Mask
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2987331137401676974
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4069877967412693113}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6530845191936304500}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 61.324, y: 61.324}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &7436112283728199014
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4069877967412693113}
+  m_CullTransparentMesh: 1
+--- !u!114 &5616646902986122397
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4069877967412693113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.90943396, g: 0.3483303, b: 0.3483303, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4aefccd10a1c44e4e98110b95d6c80e9, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 0
+  m_FillClockwise: 0
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7893306725387225855
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4069877967412693113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ae2d6af53fbe6db40a20f4a4b0bf6790, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maskImage: {fileID: 0}
+  wipeDuration: 5
+  timer: 0
+  isWiping: 0
+  rune: 0
 --- !u!1 &4322119586502888650
 GameObject:
   m_ObjectHideFlags: 0
@@ -7013,6 +7292,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2987331137401676974}
   - {fileID: 1628818740849795542}
   m_Father: {fileID: 6213094584652170588}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9737,6 +10017,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 18962347362536874}
   - {fileID: 4523470750451187494}
   m_Father: {fileID: 4682508325720008318}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -13392,6 +13673,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 8603892743095651066}
   - {fileID: 1563055979635132370}
   m_Father: {fileID: 8915571418562102925}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/Prototyping Scene - EDITOR ONLY/Level1.unity
+++ b/Assets/Scenes/Prototyping Scene - EDITOR ONLY/Level1.unity
@@ -9252,6 +9252,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 494741201}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &494903735 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1961321689321425547, guid: 03d516b99d08f404889216785393e3b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6276057131004143166}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &501363934
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -11520,6 +11526,18 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 514625577}
   m_SourcePrefab: {fileID: 100100000, guid: 3fd9bd3cbb99dab4f8d168017974bb75, type: 3}
+--- !u!1 &602419632 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3428076354966198461, guid: 03d516b99d08f404889216785393e3b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6276057131004143166}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &605187455 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4069877967412693113, guid: 03d516b99d08f404889216785393e3b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6276057131004143166}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &607774844
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -41402,6 +41420,26 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 46169212859836447, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 46169212859836447, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 46169212859836447, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 46169212859836447, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 217161951704523622, guid: 03d516b99d08f404889216785393e3b4,
         type: 3}
       propertyPath: m_Pivot.x
@@ -41504,8 +41542,33 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 258094442363363315, guid: 03d516b99d08f404889216785393e3b4,
         type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 258094442363363315, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -849.18555
+      value: -849.1852
+      objectReference: {fileID: 0}
+    - target: {fileID: 420269677130710042, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 420269677130710042, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 420269677130710042, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 420269677130710042, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 827027597083162945, guid: 03d516b99d08f404889216785393e3b4,
         type: 3}
@@ -41552,6 +41615,31 @@ PrefabInstance:
       propertyPath: m_Size
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1506607329902614722, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2135730181709304577, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2135730181709304577, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2135730181709304577, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2135730181709304577, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2276330256520582569, guid: 03d516b99d08f404889216785393e3b4,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -41587,6 +41675,26 @@ PrefabInstance:
       propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 555665699}
+    - target: {fileID: 3760278310943486113, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3760278310943486113, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3760278310943486113, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3760278310943486113, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4600103718067225390, guid: 03d516b99d08f404889216785393e3b4,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -41667,6 +41775,26 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 555665699}
+    - target: {fileID: 6497652828710283819, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6497652828710283819, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6497652828710283819, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6497652828710283819, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6542115310543512022, guid: 03d516b99d08f404889216785393e3b4,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -41702,6 +41830,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: Canvas
       objectReference: {fileID: 0}
+    - target: {fileID: 7827048161096296750, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7827048161096296750, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7827048161096296750, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7827048161096296750, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7853171360955162937, guid: 03d516b99d08f404889216785393e3b4,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -41732,6 +41880,26 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 233272667}
+    - target: {fileID: 9086779119665387715, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9086779119665387715, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9086779119665387715, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9086779119665387715, guid: 03d516b99d08f404889216785393e3b4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -41747,10 +41915,19 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 199740593767521235, guid: 22d70330496e4474db168f477a4993e2,
         type: 3}
-      propertyPath: meteorPrefab
+      propertyPath: meteorKeyMask
       value: 
-      objectReference: {fileID: 830794206325096820, guid: 226f321f7102b9c41b5a43acaf784d7d,
+      objectReference: {fileID: 605187455}
+    - target: {fileID: 199740593767521235, guid: 22d70330496e4474db168f477a4993e2,
         type: 3}
+      propertyPath: confusionKeyMask
+      value: 
+      objectReference: {fileID: 602419632}
+    - target: {fileID: 199740593767521235, guid: 22d70330496e4474db168f477a4993e2,
+        type: 3}
+      propertyPath: lightningKeyMask
+      value: 
+      objectReference: {fileID: 494903735}
     - target: {fileID: 199740593767521235, guid: 22d70330496e4474db168f477a4993e2,
         type: 3}
       propertyPath: meteorCooldownText
@@ -41816,11 +41993,6 @@ PrefabInstance:
       propertyPath: healthText
       value: 
       objectReference: {fileID: 1728860207}
-    - target: {fileID: 3088496653915348084, guid: 22d70330496e4474db168f477a4993e2,
-        type: 3}
-      propertyPath: startingMoney
-      value: 1000
-      objectReference: {fileID: 0}
     - target: {fileID: 4222203108005065239, guid: 22d70330496e4474db168f477a4993e2,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/Prototyping Scene - EDITOR ONLY/Level1.unity
+++ b/Assets/Scenes/Prototyping Scene - EDITOR ONLY/Level1.unity
@@ -20959,12 +20959,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1109568917}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1112038054 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5152633597433253196, guid: 03d516b99d08f404889216785393e3b4,
-    type: 3}
-  m_PrefabInstance: {fileID: 6276057131004143166}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1113608427
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -41055,7 +41049,7 @@ PrefabInstance:
         type: 3}
       propertyPath: towerSelection
       value: 
-      objectReference: {fileID: 1112038054}
+      objectReference: {fileID: 6276057131004143167}
     - target: {fileID: 6818719110386909350, guid: 90319159318b32846a7006408bcbd4c6,
         type: 3}
       propertyPath: autoStartButton
@@ -41548,7 +41542,7 @@ PrefabInstance:
     - target: {fileID: 258094442363363315, guid: 03d516b99d08f404889216785393e3b4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -849.1852
+      value: -430.81497
       objectReference: {fileID: 0}
     - target: {fileID: 420269677130710042, guid: 03d516b99d08f404889216785393e3b4,
         type: 3}
@@ -41905,6 +41899,12 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 03d516b99d08f404889216785393e3b4, type: 3}
+--- !u!1 &6276057131004143167 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2365980870169665526, guid: 03d516b99d08f404889216785393e3b4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6276057131004143166}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6321285439559530928
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Enemy/NavMeshMovement.cs
+++ b/Assets/Scripts/Enemy/NavMeshMovement.cs
@@ -7,6 +7,7 @@ public class NavMeshMovement : MonoBehaviour
     [NonSerialized] public Transform target;
     [SerializeField] public NavMeshAgent agent;
     private Vector3 originalPositon;
+    public float remainingDist;
 
     void Start()
     {
@@ -14,6 +15,11 @@ public class NavMeshMovement : MonoBehaviour
         agent = GetComponent<NavMeshAgent>();
         agent.SetDestination(target.position);
         originalPositon = gameObject.transform.position;
+    }
+
+    private void Update()
+    {
+        remainingDist = agent.remainingDistance;
     }
 
     public bool ReachedEnd()

--- a/Assets/Scripts/Managers/UIManager.cs
+++ b/Assets/Scripts/Managers/UIManager.cs
@@ -82,8 +82,15 @@ public class UIManager : MonoBehaviour
         popUpDuration = 0;
         showTowers = true;
         toggleTowersClickable = true;
-        towerPanelCollapsedPosition = collapsePositionTowerPanelRectTransform.anchoredPosition;
-        towerPanelExpandedPosition = towersPanel.anchoredPosition;
+        if (collapsePositionTowerPanelRectTransform != null)
+        {
+            towerPanelCollapsedPosition = collapsePositionTowerPanelRectTransform.anchoredPosition;
+        }
+        if (towersPanel != null)
+        {
+            towerPanelExpandedPosition = towersPanel.anchoredPosition;
+        }
+            
     }
 
     public void GameOver()

--- a/Assets/Scripts/PlayerScripts/RunePlacement.cs
+++ b/Assets/Scripts/PlayerScripts/RunePlacement.cs
@@ -3,6 +3,24 @@ using UnityEngine;
 
 public class RunePlacement : MonoBehaviour
 {
+    #region Singleton
+    private static RunePlacement instance;
+
+    public static RunePlacement Instance
+    {
+        get
+        {
+            if (instance == null)
+                instance = FindObjectOfType(typeof(RunePlacement)) as RunePlacement;
+            return instance;
+        }
+        set
+        {
+            instance = value;
+        }
+    }
+    #endregion
+
     public GameObject meteorPreviewPrefab;
     public GameObject lightingPreviewPrefab;
     public GameObject confusionPreviewPrefab;
@@ -19,9 +37,9 @@ public class RunePlacement : MonoBehaviour
     public float lightningCost = 50;
     public float confusionCost = 50;
 
-    private float meteorCooldown = 5f;
-    private float lightningCooldown = 7f;
-    private float confusionCooldown = 6f;
+    public float meteorCooldown = 5f;
+    public float lightningCooldown = 7f;
+    public float confusionCooldown = 6f;
 
     private float meteorCooldownTimer = 0f;
     private float lightningCooldownTimer = 0f;
@@ -31,6 +49,10 @@ public class RunePlacement : MonoBehaviour
     public TextMeshProUGUI meteorCooldownText;
     public TextMeshProUGUI lightningCooldownText;
     public TextMeshProUGUI confusionCooldownText;
+
+    public GameObject meteorKeyMask;
+    public GameObject lightningKeyMask;
+    public GameObject confusionKeyMask;
 
     public enum SkillType
     {
@@ -167,16 +189,25 @@ public class RunePlacement : MonoBehaviour
             switch (selectedSkill)
             {
                 case SkillType.Meteor:
-                    if (CastMeteor(castPosition)) 
+                    if (CastMeteor(castPosition))
+                    {
                         meteorCooldownTimer = meteorCooldown;
+                        meteorKeyMask.GetComponent<CDRadialWipe>().StartWipe();
+                    }
                     break;
                 case SkillType.Lightning:
                     if (CastLightning(castPosition))
+                    {
                         lightningCooldownTimer = lightningCooldown;
+                        lightningKeyMask.GetComponent<CDRadialWipe>().StartWipe();
+                    }
                     break;
                 case SkillType.Confusion:
                     if (CastConfusion(castPosition))
+                    {
                         confusionCooldownTimer = confusionCooldown;
+                        confusionKeyMask.GetComponent<CDRadialWipe>().StartWipe();
+                    }
                     break;
             }
 

--- a/Assets/Scripts/PlayerScripts/TowerPlacement.cs
+++ b/Assets/Scripts/PlayerScripts/TowerPlacement.cs
@@ -37,15 +37,22 @@ public class TowerPlacement : MonoBehaviour
     Color redColor = Color.red;
     Color blueColor = Color.blue;
     GameManager gameManager;
+    private bool resetPath;
     void Start()
     {
         gameManager = GameManager.Instance;
         canPlace = true;
         player = GetComponent<Player>();
+        resetPath = false;
     }
 
     private void Update()
     {
+        if (resetPath)
+        {
+            ResetPath();
+        }
+
         if (currentTowerBeingPlaced != null)
         {
             UIManager.Instance.ToggleDeselect(true);
@@ -115,14 +122,16 @@ public class TowerPlacement : MonoBehaviour
                                     Destroy(currentTowerBeingPlaced);
                                     UIManager.Instance.SendPopUp("Cannot Place Here!");
                                     UIManager.Instance.ToggleDeselect(false);
+                                    resetPath = true;
                                 }
                             }
                             else
                             {
                                 towerCollider.isTrigger = true;
                                 Destroy(currentTowerBeingPlaced);
-                                UIManager.Instance.SendPopUp("Cannot Place Here!");
+                                UIManager.Instance.SendPopUp("Cannot Place Here! All paths blocked");
                                 UIManager.Instance.ToggleDeselect(false);
+                                resetPath = true;
                             }
 
                         }
@@ -222,5 +231,16 @@ public class TowerPlacement : MonoBehaviour
 
         }
         pathBlocked = false; ;
+    }
+
+    private void ResetPath()
+    {
+        NavMeshPath path = new NavMeshPath();
+        dummySurface.BuildNavMesh();
+        foreach (NavMeshAgent agent in agents)
+        {
+            agent.GetComponent<NavMeshMovement>().ResetDestination();
+        }
+        resetPath = false;
     }
 }

--- a/Assets/Scripts/Runes/CDRadialWipe.cs
+++ b/Assets/Scripts/Runes/CDRadialWipe.cs
@@ -1,0 +1,53 @@
+using UnityEngine.UI;
+using UnityEngine;
+
+public class CDRadialWipe : MonoBehaviour
+{
+    public Image maskImage;  // Reference to the Image component (mask)
+    public float wipeDuration = 5f;  // Time in seconds for full wipe
+    public float timer = 0f;
+    public bool isWiping = false;
+
+    [SerializeField] RunePlacement.SkillType rune;
+
+    private void Start()
+    {
+        maskImage = GetComponent<Image>();
+        switch(rune)
+        {
+            case RunePlacement.SkillType.Meteor:
+                wipeDuration = RunePlacement.Instance.meteorCooldown;
+                break;
+            case RunePlacement.SkillType.Lightning:
+                wipeDuration = RunePlacement.Instance.lightningCooldown;
+                break;
+            case RunePlacement.SkillType.Confusion:
+                wipeDuration = RunePlacement.Instance.confusionCooldown;
+                break;
+        }
+    }
+
+    void Update()
+    {
+        if (isWiping)
+        {
+            timer += Time.deltaTime;
+            // Calculate the fill amount based on timer
+            float fillAmount = 1 - timer / wipeDuration;
+
+            // Set the fill amount to the mask image
+            maskImage.fillAmount = Mathf.Clamp01(fillAmount);
+
+            //// If the wipe is complete, stop the process
+            if (timer >= wipeDuration)
+            {
+                isWiping = false;
+            }
+        }
+    }
+
+    public void StartWipe()
+    {
+        isWiping = true;
+    }
+}

--- a/Assets/Scripts/Runes/CDRadialWipe.cs.meta
+++ b/Assets/Scripts/Runes/CDRadialWipe.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae2d6af53fbe6db40a20f4a4b0bf6790
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Towers/TowerTargetting.cs
+++ b/Assets/Scripts/Towers/TowerTargetting.cs
@@ -150,16 +150,5 @@ public class TowerTargetting
                     break;
             }
         }
-
-        //private float GetDistanceToEnd(EnemyDataValues enemyToEvaluate)
-        //{
-        //    float finalDistance = Vector3.Distance(enemyToEvaluate.enemyPosition, _nodePositions[enemyToEvaluate.nodeIndex]);
-
-        //    for (int i = enemyToEvaluate.nodeIndex; i < _nodeDistances.Length; i++)
-        //    {
-        //        finalDistance += _nodeDistances[i];
-        //    }
-        //    return finalDistance;
-        //}
     }
 }

--- a/Assets/Scripts/Towers/TowerTargetting.cs
+++ b/Assets/Scripts/Towers/TowerTargetting.cs
@@ -35,7 +35,8 @@ public class TowerTargetting
             Enemy currentEnemy = enemiesInRange[i].GetComponent<Enemy>();
             int enemyIndexInList = enemySpawner.spawnedEnemies.FindIndex(x => x == currentEnemy);
 
-            enemiesToCalculate[i] = new EnemyDataValues(currentEnemy.transform.position, currentEnemy.nodeIndex, currentEnemy.currentHealth, enemyIndexInList);
+            enemiesToCalculate[i] = new EnemyDataValues(currentEnemy.transform.position, currentEnemy.nodeIndex, currentEnemy.currentHealth, enemyIndexInList,
+                currentEnemy.GetComponent<NavMeshMovement>().remainingDist);
         }
 
         SearchForEnemy enemySearchJob = new SearchForEnemy
@@ -51,10 +52,10 @@ public class TowerTargetting
         switch (targetType)
         {
             case TargetType.First:
-                enemySearchJob.compareValue = Mathf.NegativeInfinity;
+                enemySearchJob.compareValue = Mathf.Infinity;
                 break;
             case TargetType.Last:
-                enemySearchJob.compareValue = Mathf.Infinity;
+                enemySearchJob.compareValue = Mathf.NegativeInfinity;
                 break;
             case TargetType.Close:
                 enemySearchJob.compareValue = Mathf.Infinity;
@@ -84,18 +85,20 @@ public class TowerTargetting
 
     struct EnemyDataValues
     {
-        public EnemyDataValues(Vector3 enemyPosition, int nodeIndex, float health, int enemyIndex)
+        public EnemyDataValues(Vector3 enemyPosition, int nodeIndex, float health, int enemyIndex, float remainingDist)
         {
             this.enemyPosition = enemyPosition;
             this.nodeIndex = nodeIndex;
             this.health = health;
             this.enemyIndex = enemyIndex;
+            this.remainingDist = remainingDist;
         }
 
         public Vector3 enemyPosition;
         public int nodeIndex;
         public float health;
         public int enemyIndex;
+        public float remainingDist;
     }
 
     struct SearchForEnemy : IJobFor
@@ -114,16 +117,16 @@ public class TowerTargetting
             switch (targetingType)
             {
                 case TargetType.First:
-                    distance = GetDistanceToEnd(_enemiesToCalculate[index]);
-                    if (distance > compareValue)
+                    distance = _enemiesToCalculate[index].remainingDist;
+                    if (distance < compareValue)
                     {
                         _enemyToIndex[0] = index;
                         compareValue = distance;
                     }
                     break;
                 case TargetType.Last:
-                    distance = GetDistanceToEnd(_enemiesToCalculate[index]);
-                    if (distance < compareValue)
+                    distance = _enemiesToCalculate[index].remainingDist;
+                    if (distance > compareValue)
                     {
                         _enemyToIndex[0] = index;
                         compareValue = distance;
@@ -148,15 +151,15 @@ public class TowerTargetting
             }
         }
 
-        private float GetDistanceToEnd(EnemyDataValues enemyToEvaluate)
-        {
-            float finalDistance = Vector3.Distance(enemyToEvaluate.enemyPosition, _nodePositions[enemyToEvaluate.nodeIndex]);
+        //private float GetDistanceToEnd(EnemyDataValues enemyToEvaluate)
+        //{
+        //    float finalDistance = Vector3.Distance(enemyToEvaluate.enemyPosition, _nodePositions[enemyToEvaluate.nodeIndex]);
 
-            for (int i = enemyToEvaluate.nodeIndex; i < _nodeDistances.Length; i++)
-            {
-                finalDistance += _nodeDistances[i];
-            }
-            return finalDistance;
-        }
+        //    for (int i = enemyToEvaluate.nodeIndex; i < _nodeDistances.Length; i++)
+        //    {
+        //        finalDistance += _nodeDistances[i];
+        //    }
+        //    return finalDistance;
+        //}
     }
 }


### PR DESCRIPTION
- Fixed bug where path would no longer show up after placing a tower that would block all enemy paths
- Fixed bug where title screen would crash due to unassigned variables
- Changed tower targeting to use actual remaining distance for each enemy instead of node distance
- Added radial wipe to the Rune UI to indicate remaining cooldown
- Fixed bug where tower selection panel wasn't completely hidden when casting rune